### PR TITLE
add dummy prior

### DIFF
--- a/Rlgt/src/stan_files/LGT.stan
+++ b/Rlgt/src/stan_files/LGT.stan
@@ -73,12 +73,17 @@ model {
 	
 	if(USE_SMOOTHED_ERROR)
 		innovSizeInit~ cauchy(y[1]/100,CAUCHY_SD) T[0,];
-		
+	else
+    innovSizeInit~ normal(0, 1) T[0,];
+	
 	if (USE_REGRESSION) {
 		regCoef ~ cauchy(0, REG_CAUCHY_SD);
 		regOffset ~ cauchy(0, reg0CauchySd);
-	}	
-  	bInit ~ cauchy(0,CAUCHY_SD);
+	}	else {
+		regCoef ~ normal(0, 1);
+		regOffset ~ normal(0, 1);
+	}
+  bInit ~ cauchy(0,CAUCHY_SD);
 	
 	for (t in 2:N) {
 	  if (USE_SMOOTHED_ERROR==0)

--- a/Rlgt/src/stan_files/S2GT.stan
+++ b/Rlgt/src/stan_files/S2GT.stan
@@ -201,12 +201,17 @@ model {
 	levSm ~ beta(1, 2);
 	
 	if(USE_SMOOTHED_ERROR)
-		innovSizeInit~ cauchy(y[1]/100,CAUCHY_SD) T[0,];
+		innovSizeInit ~ cauchy(y[1]/100,CAUCHY_SD) T[0,];
+	else
+	  innovSizeInit ~ normal(0, 1) T[0,];
 		
 	if (USE_REGRESSION) {
 		regCoef ~ cauchy(0, REG_CAUCHY_SD);
 		regOffset ~ cauchy(0, reg0CauchySd);
-	}		
+	}	else {
+		regCoef ~ normal(0, 1);
+		regOffset ~ normal(0, 1);
+	}
 	
 	if (SEASONALITY_TYPE==0) {//HW
 		for (t in 1:SEASONALITY) 

--- a/Rlgt/src/stan_files/SGT.stan
+++ b/Rlgt/src/stan_files/SGT.stan
@@ -162,11 +162,16 @@ model {
 	
 	if(USE_SMOOTHED_ERROR)
 		innovSizeInit~ cauchy(y[1]/100,CAUCHY_SD) T[0,];
-		
+	else
+    innovSizeInit~ normal(0, 1) T[0,];
+
 	if (USE_REGRESSION) {
 		regCoef ~ cauchy(0, REG_CAUCHY_SD);
 		regOffset ~ cauchy(0, reg0CauchySd);
-	}		
+	}	else {
+		regCoef ~ normal(0, 1);
+		regOffset ~ normal(0, 1);
+	}
 	
 	if (SEASONALITY_TYPE==0) {//HW
 		for (t in 1:SEASONALITY) 


### PR DESCRIPTION
Leaving unconstrained parameters `innovSizeInit`, `regCoef` and `regOffset` no prior in model block, it is implicitly assuming uniform (improper) prior. Theoretically it would not affect HMC. However, Stan does produce tons of divergent transitions. Set dummy priors to avoid it.

Example:

```r
library(rstan)

without_prior_code =
'data {
  int<lower=0> N;
  vector[N] y;
}
parameters {
  real mu;
  real<lower=0> dummy;
}
model {
  y ~ normal(mu, 1);
}
'
model_without_prior = stan_model(model_code = without_prior_code)

set.seed(123)
y = rnorm(100, 2.3, 1)
data = list(N = length(y), y = y)

samples_without_prior = sampling(object = model_without_prior, 
                                 data = data, chains = 1, seed = 123)
check_hmc_diagnostics(samples_without_prior)
```
It would produce
```
Divergences:
758 of 1000 iterations ended with a divergence (75.8%).
Try increasing 'adapt_delta' to remove the divergences.

Tree depth:
0 of 1000 iterations saturated the maximum tree depth of 10.

Energy:
E-BFMI indicated no pathological behavior.
```

Btw, the original stan files has mixing tabs and spaces. That's why the diff is displayed in github with very ugly spacing.
